### PR TITLE
Use mac-address instead of mac

### DIFF
--- a/types/firewall.go
+++ b/types/firewall.go
@@ -70,7 +70,7 @@ type Source struct {
 	AddressGroup *string    `json:"-" tfsdk:"address_group"`
 	PortGroup    *string    `json:"-" tfsdk:"port_group"`
 	Port         *PortRange `json:"-" tfsdk:"port"`
-	MAC          *string    `json:"mac,omitempty" tfsdk:"mac"`
+	MAC          *string    `json:"mac-address,omitempty" tfsdk:"mac"`
 }
 
 type Destination struct {


### PR DESCRIPTION
## Note: i haven't end-to-end tested this with terraform-provider-edge

Building out my home ruleset using the fantastic arm64 build (thank you again) -- hitting an issue for rules with a mac address source

```
Could not unmarshal operation from data {"SET": {"error": {"firewall name main_firewall rule 60 source mac
│ xx:xx:xx:xx:xx:xx": "The specified configuration node is not valid\n
```

I checked network calls when using the config editor, and I believe it uses `mac-address` instead of `mac`. Would appreciate help testing 