### PR TITLE
Add support for attaching vlans to firewall interfaces

### DIFF
--- a/interfaces/ethernet/ethernet_test.go
+++ b/interfaces/ethernet/ethernet_test.go
@@ -1,0 +1,57 @@
+package ethernet
+
+import (
+	"encoding/json"
+	"github.com/frankgreco/edge-sdk-go/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestToEthernetMapMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		id       string
+		firewall *types.FirewallAttachment
+		expected string
+	}{
+		{
+			name:     "no vlan and no firewall",
+			id:       "eth0",
+			expected: `{"eth0":{}}`,
+		},
+		{
+			name:     "vlan and no firewall",
+			id:       "eth0.20",
+			expected: `{"eth0":{"vif":{"20":{}}}}`,
+		},
+		{
+			name:     "no vlan and a firewall",
+			id:       "eth0",
+			firewall: &types.FirewallAttachment{In: strptr("eth0")},
+			expected: `{"eth0":{"firewall":{"in":{"name":"eth0"}}}}`,
+		},
+		{
+			name:     "vlan and a firewall",
+			id:       "eth0.20",
+			firewall: &types.FirewallAttachment{In: strptr("eth0.20")},
+			expected: `{"eth0":{"vif":{"20":{"firewall":{"in":{"name":"eth0.20"}}}}}}`,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := json.Marshal(toEthernetMap(tt.id, tt.firewall))
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, string(out))
+		})
+	}
+}
+
+func strptr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/types/ethernet.go
+++ b/types/ethernet.go
@@ -20,15 +20,20 @@ type FirewallAttachment struct {
 	Local     *string        `json:"local,omitempty" tfsdk:"local"`
 }
 
+type VirtualInterface struct {
+	Firewall *FirewallAttachment `json:"firewall,omitempty" tfsdk:"-"`
+}
+
 type Ethernet struct {
-	ID          string              `json:"-" tfsdk:"id"`
-	Addresses   []string            `json:"address,omitempty" tfsdk:"-"`
-	Description string              `json:"description,omitempty" tfsdk:"-"`
-	DHCPOptions *DHCPOptions        `json:"dhcp-options,omitempty" tfsdk:"-"`
-	Duplex      string              `json:"duplex,omitempty" tfsdk:"-"`
-	Speed       string              `json:"speed,omitempty" tfsdk:"-"`
-	IP          *IP                 `json:"ip,omitempty" tfsdk:"-"`
-	Firewall    *FirewallAttachment `json:"firewall" tfsdk:"-"`
+	ID          string                       `json:"-" tfsdk:"id"`
+	Addresses   []string                     `json:"address,omitempty" tfsdk:"-"`
+	Description string                       `json:"description,omitempty" tfsdk:"-"`
+	DHCPOptions *DHCPOptions                 `json:"dhcp-options,omitempty" tfsdk:"-"`
+	Duplex      string                       `json:"duplex,omitempty" tfsdk:"-"`
+	Speed       string                       `json:"speed,omitempty" tfsdk:"-"`
+	IP          *IP                          `json:"ip,omitempty" tfsdk:"-"`
+	Firewall    *FirewallAttachment          `json:"firewall,omitempty" tfsdk:"-"`
+	Vif         map[string]*VirtualInterface `json:"vif,omitempty" tfsdk:"-"`
 }
 
 func (a *FirewallAttachment) GetID() string {


### PR DESCRIPTION
Noticed this in https://github.com/frankgreco/terraform-provider-edge: 

```
data "edge_interface_ethernet" "eth3_20" {
  id = "eth3.20"
}
```

where trying to attach a vlan to a firewall throws an error 

```
Could not unmarshal operation from data {"SET": {"error": {"interfaces ethernet eth3.20 firewall in name
│ main_firewall": "interface ethernet eth3.20: not a valid name\n\nValue validation failed\n"
```

Here's the network calls for attaching to a regular ethernet interface (**left**) vs. a vlan (**right**)

<img width="1131" alt="Screen Shot 2022-10-15 at 9 54 54 AM" src="https://user-images.githubusercontent.com/3915897/195995943-f2323e99-48ae-4dca-932c-a0728382e541.png">

I haven't tested this yet.

